### PR TITLE
Using serde::Value as the value type on authorization key-value pairs.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -86,9 +86,11 @@ pub fn execute(client: &Client, request: parser::Request) -> Result<(Response, u
 
     let auth = &details.auth;
     if auth.auth_type == "basic" {
-        let username = auth.basic.iter().find(|kv| kv.key == "username").unwrap().value.clone();
-        let password = auth.basic.iter().find(|kv| kv.key == "password").unwrap().value.clone();
-        builder = builder.basic_auth(username, Some(password));
+        let username = auth.basic.iter().find(|kv| kv.key == "username").unwrap().value.as_str();
+        let password = auth.basic.iter().find(|kv| kv.key == "password").unwrap().value.as_str();
+        if let Some(username) = username {
+            builder = builder.basic_auth(username, password);
+        }
     }
 
     match details.body.mode.as_ref() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,7 +70,13 @@ pub struct Auth {
     pub auth_type: String,
 
     #[serde(default)]
-    pub basic: Vec<KeyValue>,
+    pub basic: Vec<AuthKeyValue>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct AuthKeyValue {
+    pub key: String,
+    pub value: Value, 
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]


### PR DESCRIPTION
Fixes #25.

Signed-off-by: Kevin Swiber <kswiber@gmail.com>